### PR TITLE
Removed unlimited Ascend after moonlord

### DIFF
--- a/Utils/WorldManager.cs
+++ b/Utils/WorldManager.cs
@@ -99,8 +99,6 @@ namespace AnotherRpgMod.Utils
                 limit = 5;
                 if (NPC.downedPlantBoss && limit < 15)
                     limit = 15;
-                if (NPC.downedMoonlord)
-                    return 999;
             }
 
             return Mathf.FloorInt(limit);


### PR DESCRIPTION
This contributes to integer overflow in damage numbers breaking the game with mods that adds lots of bosses.  You can already disable the cap if you choose so forcing it on mods with lots of bosses after moonlord is not ideal.